### PR TITLE
feat: report の learning_plan を daily_goals へ自動同期（UI不整合の暫定対応）

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ Claude Code / Claude Desktop 上で自然言語で操作できます:
 - `daily_list` - 日次目標一覧
 - `daily_update` - 日次目標更新
 
+> **注**: `report_create` / `report_update` で `learning_plan` を指定すると、該当日の日次目標アイテムへ自動反映されます（改行区切りで `items` に position 昇順マッピング）。アプリUIの「Plan」欄は `daily_goals` を参照するため、レポートの Plan と UI 表示が乖離しないようにするための挙動です。根本解決は API 側対応待ち（[koki-kato/pdca-app#90](https://github.com/koki-kato/pdca-app/issues/90)）。
+
 ### コメント（3）
 - `comment_list` - コメント一覧
 - `comment_create` - コメント作成

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Claude Code / Claude Desktop 上で自然言語で操作できます:
 - `daily_list` - 日次目標一覧
 - `daily_update` - 日次目標更新
 
-> **注**: `report_create` / `report_update` で `learning_plan` を指定すると、該当日の日次目標アイテムへ自動反映されます（改行区切りで `items` に position 昇順マッピング）。アプリUIの「Plan」欄は `daily_goals` を参照するため、レポートの Plan と UI 表示が乖離しないようにするための挙動です。根本解決は API 側対応待ち（[koki-kato/pdca-app#90](https://github.com/koki-kato/pdca-app/issues/90)）。
+> **注**: `report_create` / `report_update` で `learning_plan` を指定すると、該当日の日次目標アイテムへ自動反映されます（改行区切りで `items` に position 昇順マッピング）。アプリUI（Rails HTML）はHTMLコントローラ側で `find_or_create_daily_goal` による紐付けが行われるため問題にならないが、API直叩きでは紐付けがなく表示が乖離する。この同期はAPIクライアント側の責務として実装（[koki-kato/pdca-app#90](https://github.com/koki-kato/pdca-app/issues/90) で合意済み・クローズ）。
 
 ### コメント（3）
 - `comment_list` - コメント一覧

--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ Claude Code / Claude Desktop 上で自然言語で操作できます:
 - `daily_update` - 日次目標更新
 
 > **注**: `report_create` / `report_update` で `learning_plan` を指定すると、該当日の日次目標アイテムへ自動反映されます（改行区切りで `items` に position 昇順マッピング）。アプリUI（Rails HTML）はHTMLコントローラ側で `find_or_create_daily_goal` による紐付けが行われるため問題にならないが、API直叩きでは紐付けがなく表示が乖離する。この同期はAPIクライアント側の責務として実装（[koki-kato/pdca-app#90](https://github.com/koki-kato/pdca-app/issues/90) で合意済み・クローズ）。
+>
+> **同期仕様の詳細**:
+> - 末尾改行（`"a\n"` の `\n` 部分）は無視
+> - 中間の空行（`"a\n\nc"` の2行目）は空文字として対応する item を上書き
+> - 行数 < item数 の場合、余った item は変更せず残す
+> - 行数 > item数 の場合、余った行は無視
 
 ### コメント（3）
 - `comment_list` - コメント一覧

--- a/src/tools/reports.ts
+++ b/src/tools/reports.ts
@@ -2,8 +2,10 @@ import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { ApiClient } from '../client/api-client.js';
 import type { Report, ReportListResponse } from '../types/api-types.js';
-import { handleApiCall } from '../utils/response.js';
+import { formatSuccess, formatError, handleApiCall } from '../utils/response.js';
 import { todayJST } from '../utils/date.js';
+import { syncDailyGoalForDate } from '../utils/sync-daily-goal.js';
+import { ApiError } from '../client/api-client.js';
 
 const dateSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, '日付はYYYY-MM-DD形式で指定してください');
 const monthSchema = z.string().regex(/^\d{4}-\d{2}$/, '月はYYYY-MM形式で指定してください');
@@ -30,9 +32,21 @@ export function registerReportTools(server: McpServer, apiClient: ApiClient): vo
         ...params,
         report_date: params.report_date ?? todayJST(),
       };
-      return handleApiCall(() =>
-        apiClient.post<{ report: Report }>('/api/v1/reports', { report })
-      );
+      try {
+        const response = await apiClient.post<{ report: Report }>(
+          '/api/v1/reports',
+          { report }
+        );
+        if (report.learning_plan) {
+          await syncDailyGoalForDate(apiClient, report.report_date, report.learning_plan);
+        }
+        return formatSuccess(response);
+      } catch (e) {
+        if (e instanceof ApiError) {
+          return formatError(e.code, e.status, e.details);
+        }
+        return formatError('NETWORK_ERROR', 0);
+      }
     }
   );
 
@@ -114,9 +128,25 @@ export function registerReportTools(server: McpServer, apiClient: ApiClient): vo
     },
     async (params) => {
       const { id, ...reportFields } = params;
-      return handleApiCall(() =>
-        apiClient.patch<{ report: Report }>(`/api/v1/reports/${id}`, { report: reportFields })
-      );
+      try {
+        const response = await apiClient.patch<{ report: Report }>(
+          `/api/v1/reports/${id}`,
+          { report: reportFields }
+        );
+        if (reportFields.learning_plan && response?.report?.report_date) {
+          await syncDailyGoalForDate(
+            apiClient,
+            response.report.report_date,
+            reportFields.learning_plan
+          );
+        }
+        return formatSuccess(response);
+      } catch (e) {
+        if (e instanceof ApiError) {
+          return formatError(e.code, e.status, e.details);
+        }
+        return formatError('NETWORK_ERROR', 0);
+      }
     }
   );
 }

--- a/src/tools/reports.ts
+++ b/src/tools/reports.ts
@@ -139,6 +139,10 @@ export function registerReportTools(server: McpServer, apiClient: ApiClient): vo
             response.report.report_date,
             reportFields.learning_plan
           );
+        } else if (reportFields.learning_plan && !response?.report?.report_date) {
+          console.error(
+            '[sync-daily-goal] report_update 応答に report_date が含まれず同期をスキップ'
+          );
         }
         return formatSuccess(response);
       } catch (e) {

--- a/src/utils/sync-daily-goal.ts
+++ b/src/utils/sync-daily-goal.ts
@@ -29,13 +29,15 @@ export async function syncDailyGoalForDate(
       `/api/v1/daily_goals?${queryParams}`
     );
     dailyGoal = response?.daily_goals?.[0];
-  } catch {
+  } catch (e) {
+    console.error('[sync-daily-goal] 日次目標取得に失敗:', e);
     return;
   }
 
   if (!dailyGoal || !dailyGoal.items?.length) return;
 
-  const lines = learningPlan.split('\n');
+  const goalId = dailyGoal.id;
+  const lines = learningPlan.split(/\r?\n/);
   const sortedItems = [...dailyGoal.items].sort(
     (a, b) => a.position - b.position
   );
@@ -44,7 +46,7 @@ export async function syncDailyGoalForDate(
     .map((item, idx) => ({ item, content: lines[idx] }));
 
   await Promise.all(
-    pairs.map(({ item, content }) => updateItemSafely(apiClient, dailyGoal!.id, item, content))
+    pairs.map(({ item, content }) => updateItemSafely(apiClient, goalId, item, content))
   );
 }
 
@@ -59,7 +61,11 @@ async function updateItemSafely(
       `/api/v1/daily_goals/${dailyGoalId}/items/${item.id}`,
       { content }
     );
-  } catch {
-    // 個別失敗は無視（同期はベストエフォート）
+  } catch (e) {
+    // 個別失敗は無視（同期はベストエフォート）だが運用追跡のため stderr に残す
+    console.error(
+      `[sync-daily-goal] item ${item.id} (daily_goal ${dailyGoalId}) の更新に失敗:`,
+      e
+    );
   }
 }

--- a/src/utils/sync-daily-goal.ts
+++ b/src/utils/sync-daily-goal.ts
@@ -37,7 +37,8 @@ export async function syncDailyGoalForDate(
   if (!dailyGoal || !dailyGoal.items?.length) return;
 
   const goalId = dailyGoal.id;
-  const lines = learningPlan.split(/\r?\n/);
+  // 末尾改行は無視（ユーザーが末尾改行付きで送ると2行目のitemが空文字で上書きされるのを防ぐ）
+  const lines = learningPlan.replace(/\n+$/, '').split(/\r?\n/);
   const sortedItems = [...dailyGoal.items].sort(
     (a, b) => a.position - b.position
   );

--- a/src/utils/sync-daily-goal.ts
+++ b/src/utils/sync-daily-goal.ts
@@ -1,0 +1,65 @@
+import type { ApiClient } from '../client/api-client.js';
+import type { DailyGoal, DailyGoalItem } from '../types/api-types.js';
+
+/**
+ * レポートの learning_plan を該当日の日次目標アイテムに同期する。
+ *
+ * 背景: アプリUIの「Plan」欄は report.learning_plan ではなく daily_goals.items[].content
+ * を参照している。goal_create 時に自動生成される "N%まで進める" を learning_plan の
+ * 自由記述で上書きするためのヘルパー。
+ *
+ * 制約:
+ * - learning_plan が空/nullなら何もしない
+ * - 日次目標が存在しない/取得失敗時は静かに終了（レポート本体の成否を阻害しない）
+ * - learning_plan を改行で分割し、items を position 昇順で 1:1 マッピング
+ * - 行数不足は余った items をそのまま残し、行数超過は余った行を無視
+ * - 個別 PATCH 失敗は他 item の処理を阻害しない
+ */
+export async function syncDailyGoalForDate(
+  apiClient: ApiClient,
+  date: string,
+  learningPlan: string | null | undefined
+): Promise<void> {
+  if (!learningPlan) return;
+
+  let dailyGoal: DailyGoal | undefined;
+  try {
+    const queryParams = new URLSearchParams({ date });
+    const response = await apiClient.get<{ daily_goals: DailyGoal[] }>(
+      `/api/v1/daily_goals?${queryParams}`
+    );
+    dailyGoal = response?.daily_goals?.[0];
+  } catch {
+    return;
+  }
+
+  if (!dailyGoal || !dailyGoal.items?.length) return;
+
+  const lines = learningPlan.split('\n');
+  const sortedItems = [...dailyGoal.items].sort(
+    (a, b) => a.position - b.position
+  );
+  const pairs = sortedItems
+    .slice(0, lines.length)
+    .map((item, idx) => ({ item, content: lines[idx] }));
+
+  await Promise.all(
+    pairs.map(({ item, content }) => updateItemSafely(apiClient, dailyGoal!.id, item, content))
+  );
+}
+
+async function updateItemSafely(
+  apiClient: ApiClient,
+  dailyGoalId: number,
+  item: DailyGoalItem,
+  content: string
+): Promise<void> {
+  try {
+    await apiClient.patch<{ item: DailyGoalItem }>(
+      `/api/v1/daily_goals/${dailyGoalId}/items/${item.id}`,
+      { content }
+    );
+  } catch {
+    // 個別失敗は無視（同期はベストエフォート）
+  }
+}

--- a/tests/utils/sync-daily-goal.test.ts
+++ b/tests/utils/sync-daily-goal.test.ts
@@ -170,6 +170,60 @@ describe('syncDailyGoalForDate', () => {
     ).resolves.toBeUndefined();
   });
 
+  it('末尾改行は無視する（2行目itemを空で上書きしない）', async () => {
+    (apiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+      daily_goals: [
+        {
+          id: 100,
+          goal_date: '2026-04-18',
+          weekly_goal_id: 10,
+          items: [
+            { id: 11, content: '旧1', progress: 0, position: 0 },
+            { id: 12, content: '旧2', progress: 0, position: 1 },
+          ],
+        },
+      ],
+    });
+
+    await syncDailyGoalForDate(apiClient, '2026-04-18', 'MCP実装\n');
+
+    expect(apiClient.patch).toHaveBeenCalledTimes(1);
+    expect(apiClient.patch).toHaveBeenCalledWith(
+      '/api/v1/daily_goals/100/items/11',
+      { content: 'MCP実装' }
+    );
+  });
+
+  it('末尾改行が複数でも無視する', async () => {
+    (apiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+      daily_goals: [
+        {
+          id: 100,
+          goal_date: '2026-04-18',
+          weekly_goal_id: 10,
+          items: [
+            { id: 11, content: '旧1', progress: 0, position: 0 },
+            { id: 12, content: '旧2', progress: 0, position: 1 },
+          ],
+        },
+      ],
+    });
+
+    await syncDailyGoalForDate(apiClient, '2026-04-18', '行1\n行2\n\n\n');
+
+    expect(apiClient.patch).toHaveBeenCalledTimes(2);
+    expect(apiClient.patch).toHaveBeenNthCalledWith(
+      1,
+      '/api/v1/daily_goals/100/items/11',
+      { content: '行1' }
+    );
+    expect(apiClient.patch).toHaveBeenNthCalledWith(
+      2,
+      '/api/v1/daily_goals/100/items/12',
+      { content: '行2' }
+    );
+  });
+
   it('CRLF改行でも正しく分割する', async () => {
     (apiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({
       daily_goals: [

--- a/tests/utils/sync-daily-goal.test.ts
+++ b/tests/utils/sync-daily-goal.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { syncDailyGoalForDate } from '../../src/utils/sync-daily-goal.js';
+import type { ApiClient } from '../../src/client/api-client.js';
+import { ApiError } from '../../src/client/api-client.js';
+
+describe('syncDailyGoalForDate', () => {
+  let apiClient: ApiClient;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    apiClient = {
+      get: vi.fn(),
+      post: vi.fn(),
+      patch: vi.fn(),
+      delete: vi.fn(),
+    } as unknown as ApiClient;
+  });
+
+  it('learning_planが空ならapiClientを呼ばない', async () => {
+    await syncDailyGoalForDate(apiClient, '2026-04-18', '');
+    expect(apiClient.get).not.toHaveBeenCalled();
+    expect(apiClient.patch).not.toHaveBeenCalled();
+  });
+
+  it('learning_planがnullならapiClientを呼ばない', async () => {
+    await syncDailyGoalForDate(apiClient, '2026-04-18', null);
+    expect(apiClient.get).not.toHaveBeenCalled();
+    expect(apiClient.patch).not.toHaveBeenCalled();
+  });
+
+  it('日次目標が存在する場合、1行1itemでcontentを更新する', async () => {
+    (apiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+      daily_goals: [
+        {
+          id: 1642,
+          goal_date: '2026-04-18',
+          weekly_goal_id: 246,
+          items: [
+            { id: 3760, content: '14%まで進める', progress: 0, position: 0 },
+          ],
+        },
+      ],
+    });
+
+    await syncDailyGoalForDate(apiClient, '2026-04-18', 'MCP実装');
+
+    expect(apiClient.patch).toHaveBeenCalledWith(
+      '/api/v1/daily_goals/1642/items/3760',
+      { content: 'MCP実装' }
+    );
+  });
+
+  it('複数行の場合、position順にitemsへ1:1マッピング', async () => {
+    (apiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+      daily_goals: [
+        {
+          id: 100,
+          goal_date: '2026-04-18',
+          weekly_goal_id: 10,
+          items: [
+            { id: 11, content: '旧1', progress: 0, position: 0 },
+            { id: 12, content: '旧2', progress: 0, position: 1 },
+          ],
+        },
+      ],
+    });
+
+    await syncDailyGoalForDate(apiClient, '2026-04-18', '新1\n新2');
+
+    expect(apiClient.patch).toHaveBeenCalledTimes(2);
+    expect(apiClient.patch).toHaveBeenNthCalledWith(
+      1,
+      '/api/v1/daily_goals/100/items/11',
+      { content: '新1' }
+    );
+    expect(apiClient.patch).toHaveBeenNthCalledWith(
+      2,
+      '/api/v1/daily_goals/100/items/12',
+      { content: '新2' }
+    );
+  });
+
+  it('行数 < items数なら余ったitemは更新しない', async () => {
+    (apiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+      daily_goals: [
+        {
+          id: 100,
+          goal_date: '2026-04-18',
+          weekly_goal_id: 10,
+          items: [
+            { id: 11, content: '旧1', progress: 0, position: 0 },
+            { id: 12, content: '旧2', progress: 0, position: 1 },
+          ],
+        },
+      ],
+    });
+
+    await syncDailyGoalForDate(apiClient, '2026-04-18', '新1のみ');
+
+    expect(apiClient.patch).toHaveBeenCalledTimes(1);
+    expect(apiClient.patch).toHaveBeenCalledWith(
+      '/api/v1/daily_goals/100/items/11',
+      { content: '新1のみ' }
+    );
+  });
+
+  it('行数 > items数なら余った行は無視', async () => {
+    (apiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+      daily_goals: [
+        {
+          id: 100,
+          goal_date: '2026-04-18',
+          weekly_goal_id: 10,
+          items: [{ id: 11, content: '旧1', progress: 0, position: 0 }],
+        },
+      ],
+    });
+
+    await syncDailyGoalForDate(apiClient, '2026-04-18', '新1\n新2\n新3');
+
+    expect(apiClient.patch).toHaveBeenCalledTimes(1);
+    expect(apiClient.patch).toHaveBeenCalledWith(
+      '/api/v1/daily_goals/100/items/11',
+      { content: '新1' }
+    );
+  });
+
+  it('日次目標が存在しない場合、何もしない', async () => {
+    (apiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+      daily_goals: [],
+    });
+
+    await syncDailyGoalForDate(apiClient, '2026-04-18', 'MCP実装');
+
+    expect(apiClient.patch).not.toHaveBeenCalled();
+  });
+
+  it('GET失敗時にexceptionをthrowせず静かに終了する', async () => {
+    (apiClient.get as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new ApiError('NOT_FOUND', 404)
+    );
+
+    await expect(
+      syncDailyGoalForDate(apiClient, '2026-04-18', 'MCP実装')
+    ).resolves.toBeUndefined();
+    expect(apiClient.patch).not.toHaveBeenCalled();
+  });
+
+  it('PATCH失敗時もexceptionをthrowしない', async () => {
+    (apiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+      daily_goals: [
+        {
+          id: 100,
+          goal_date: '2026-04-18',
+          weekly_goal_id: 10,
+          items: [
+            { id: 11, content: '旧1', progress: 0, position: 0 },
+            { id: 12, content: '旧2', progress: 0, position: 1 },
+          ],
+        },
+      ],
+    });
+    (apiClient.patch as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({ item: { id: 11, content: '新1', progress: 0, position: 0 } })
+      .mockRejectedValueOnce(new ApiError('SERVER_ERROR', 500));
+
+    await expect(
+      syncDailyGoalForDate(apiClient, '2026-04-18', '新1\n新2')
+    ).resolves.toBeUndefined();
+  });
+
+  it('positionが昇順でない場合もposition昇順で処理する', async () => {
+    (apiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+      daily_goals: [
+        {
+          id: 100,
+          goal_date: '2026-04-18',
+          weekly_goal_id: 10,
+          items: [
+            { id: 12, content: '旧2', progress: 0, position: 1 },
+            { id: 11, content: '旧1', progress: 0, position: 0 },
+          ],
+        },
+      ],
+    });
+
+    await syncDailyGoalForDate(apiClient, '2026-04-18', '新1\n新2');
+
+    expect(apiClient.patch).toHaveBeenNthCalledWith(
+      1,
+      '/api/v1/daily_goals/100/items/11',
+      { content: '新1' }
+    );
+    expect(apiClient.patch).toHaveBeenNthCalledWith(
+      2,
+      '/api/v1/daily_goals/100/items/12',
+      { content: '新2' }
+    );
+  });
+});

--- a/tests/utils/sync-daily-goal.test.ts
+++ b/tests/utils/sync-daily-goal.test.ts
@@ -8,6 +8,7 @@ describe('syncDailyGoalForDate', () => {
 
   beforeEach(() => {
     vi.restoreAllMocks();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
     apiClient = {
       get: vi.fn(),
       post: vi.fn(),
@@ -167,6 +168,89 @@ describe('syncDailyGoalForDate', () => {
     await expect(
       syncDailyGoalForDate(apiClient, '2026-04-18', '新1\n新2')
     ).resolves.toBeUndefined();
+  });
+
+  it('CRLF改行でも正しく分割する', async () => {
+    (apiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+      daily_goals: [
+        {
+          id: 100,
+          goal_date: '2026-04-18',
+          weekly_goal_id: 10,
+          items: [
+            { id: 11, content: '旧1', progress: 0, position: 0 },
+            { id: 12, content: '旧2', progress: 0, position: 1 },
+          ],
+        },
+      ],
+    });
+
+    await syncDailyGoalForDate(apiClient, '2026-04-18', '新1\r\n新2');
+
+    expect(apiClient.patch).toHaveBeenNthCalledWith(
+      1,
+      '/api/v1/daily_goals/100/items/11',
+      { content: '新1' }
+    );
+    expect(apiClient.patch).toHaveBeenNthCalledWith(
+      2,
+      '/api/v1/daily_goals/100/items/12',
+      { content: '新2' }
+    );
+  });
+
+  it('空行が含まれる場合はそのまま空文字で更新（仕様）', async () => {
+    (apiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+      daily_goals: [
+        {
+          id: 100,
+          goal_date: '2026-04-18',
+          weekly_goal_id: 10,
+          items: [
+            { id: 11, content: '旧1', progress: 0, position: 0 },
+            { id: 12, content: '旧2', progress: 0, position: 1 },
+            { id: 13, content: '旧3', progress: 0, position: 2 },
+          ],
+        },
+      ],
+    });
+
+    await syncDailyGoalForDate(apiClient, '2026-04-18', '行1\n\n行3');
+
+    expect(apiClient.patch).toHaveBeenCalledTimes(3);
+    expect(apiClient.patch).toHaveBeenNthCalledWith(
+      2,
+      '/api/v1/daily_goals/100/items/12',
+      { content: '' }
+    );
+  });
+
+  it('GETレスポンスがnull(204等)なら何もしない', async () => {
+    (apiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+    await syncDailyGoalForDate(apiClient, '2026-04-18', 'MCP実装');
+
+    expect(apiClient.patch).not.toHaveBeenCalled();
+  });
+
+  it('daily_goalsキーが無いレスポンスでも何もしない', async () => {
+    (apiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({});
+
+    await syncDailyGoalForDate(apiClient, '2026-04-18', 'MCP実装');
+
+    expect(apiClient.patch).not.toHaveBeenCalled();
+  });
+
+  it('itemsが無いdaily_goalでも何もしない', async () => {
+    (apiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+      daily_goals: [
+        { id: 100, goal_date: '2026-04-18', weekly_goal_id: 10, items: [] },
+      ],
+    });
+
+    await syncDailyGoalForDate(apiClient, '2026-04-18', 'MCP実装');
+
+    expect(apiClient.patch).not.toHaveBeenCalled();
   });
 
   it('positionが昇順でない場合もposition昇順で処理する', async () => {


### PR DESCRIPTION
## 概要

アプリUIの「Plan」欄は `report.learning_plan` ではなく `daily_goals.items[].content` を参照している仕様のため、`report_create`/`report_update` で `learning_plan` を指定してもUIに反映されない問題があった。APIクライアント側の責務として同期処理を実装。

### 背景調査結果
- アプリUI（Rails HTML）は HTMLコントローラ側で `find_or_create_daily_goal` により pdca_report と daily_goal を自動紐付けしているため表示問題なし
- 問題は API 直叩きパス（MCP 等）に限定
- バックエンド側の daily_goal / learning_plan 連携ロジックは過去複数回リグレッションが発生しており、モデル層への同期追加はリスクが高い
- 結論: APIクライアント側での同期対応とし、[koki-kato/pdca-app#90](https://github.com/koki-kato/pdca-app/issues/90) はクローズ（合意済み）

## 変更内容

- `src/utils/sync-daily-goal.ts`: 新規ヘルパー `syncDailyGoalForDate`
- `src/tools/reports.ts`: `report_create`/`report_update` 成功時に同期呼び出し
- `tests/utils/sync-daily-goal.test.ts`: 15ケース（TDDで先行作成）
- `README.md`: 挙動追記 + 関連issueリンク

## 同期仕様

- `learning_plan` 空/null → no-op
- `learning_plan.split(/\r?\n/)` で分割（CRLF対応）、`items` を position 昇順で 1:1 マッピング
- 行数不足は余ったitemsをそのまま残し、行数超過は余った行を無視
- 日次目標なし/GET失敗/個別PATCH失敗 → silent skip（レポート本体成否を阻害しない）
- 失敗時は stderr へ診断ログ

## セルフレビュー対応済み

- I4: CRLF改行対応（`split(/\r?\n/)`）
- M3: non-null assertion をローカル変数退避
- M5: stderr ログ追加
- M4: CRLF/空行/null/items空 テスト追加

## テスト

- ユニット: 72テスト全PASS（+5）
- 手動E2E: 本番API (Heroku) で `daily_update` 単体動作確認済み（PR前）
- 手動E2E（post-merge）: MCP server 再起動後、`report_create` で `learning_plan` 指定→UIのPlan欄に反映されることを確認予定

## Test Plan

- [ ] CI全緑
- [ ] マージ後、ローカルで `npm run build` → Claude Code 再起動
- [ ] `report_create` で `learning_plan="テスト"` → アプリUIのPlan欄が「テスト」に変わる
- [ ] `report_update` でも同様に反映される
- [ ] `learning_plan` 未指定 → daily_goals の既存値は変わらない