### PR TITLE
feat: goal_update 後の report.learning_plan 再同期（#3対応）

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,13 @@ Claude Code / Claude Desktop 上で自然言語で操作できます:
 - 行数 < item数 の場合、余った item は変更せず残す
 - 行数 > item数 の場合、余った行は無視
 
+### 双方向同期の挙動
+
+- `report_create` / `report_update`: `learning_plan` → `daily_goal_items` へ伝搬
+- `goal_update`: `daily_goal_items` → `report.learning_plan` へ逆伝搬（バックエンドが意図せず上書きするのを救済）
+
+**last wins ルール**: 同じ週に対して `report_update` と `goal_update` を連続で叩いた場合、**最後に呼んだツールの入力が勝つ**。通常運用では問題になりませんが、自動化スクリプト等で短時間に両方を叩く場合は実行順序に注意してください。
+
 ---
 
 ## 環境変数

--- a/src/tools/goals.ts
+++ b/src/tools/goals.ts
@@ -2,7 +2,9 @@ import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { ApiClient } from '../client/api-client.js';
 import type { WeeklyGoal } from '../types/api-types.js';
-import { handleApiCall } from '../utils/response.js';
+import { formatSuccess, formatError, handleApiCall } from '../utils/response.js';
+import { ApiError } from '../client/api-client.js';
+import { syncReportLearningPlanForWeek } from '../utils/sync-report-learning-plan.js';
 
 const dateSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, '日付はYYYY-MM-DD形式で指定してください');
 
@@ -77,9 +79,30 @@ export function registerGoalTools(server: McpServer, apiClient: ApiClient): void
     },
     async (params) => {
       const { id, items } = params;
-      return handleApiCall(() =>
-        apiClient.patch<{ weekly_goal: WeeklyGoal }>(`/api/v1/weekly_goals/${id}`, { items })
-      );
+      try {
+        const response = await apiClient.patch<{ weekly_goal: WeeklyGoal }>(
+          `/api/v1/weekly_goals/${id}`,
+          { items }
+        );
+        // goal_update 後、バックエンドが pdca_reports_controller 経由で
+        // report.learning_plan を daily_goal_items.first.content で上書きしうるため、
+        // 正しい値が learning_plan に残るよう週範囲を再同期する。
+        // (詳細: https://github.com/HIROMICHIplusSHI/pdca-mcp/issues/3)
+        const goal = response?.weekly_goal;
+        if (goal?.week_start_date && goal?.week_end_date) {
+          await syncReportLearningPlanForWeek(
+            apiClient,
+            goal.week_start_date,
+            goal.week_end_date
+          );
+        }
+        return formatSuccess(response);
+      } catch (e) {
+        if (e instanceof ApiError) {
+          return formatError(e.code, e.status, e.details);
+        }
+        return formatError('NETWORK_ERROR', 0);
+      }
     }
   );
 }

--- a/src/tools/goals.ts
+++ b/src/tools/goals.ts
@@ -79,16 +79,28 @@ export function registerGoalTools(server: McpServer, apiClient: ApiClient): void
     },
     async (params) => {
       const { id, items } = params;
+      let response: { weekly_goal: WeeklyGoal } | null;
       try {
-        const response = await apiClient.patch<{ weekly_goal: WeeklyGoal }>(
+        response = await apiClient.patch<{ weekly_goal: WeeklyGoal }>(
           `/api/v1/weekly_goals/${id}`,
           { items }
         );
-        // goal_update 後、バックエンドが pdca_reports_controller 経由で
-        // report.learning_plan を daily_goal_items.first.content で上書きしうるため、
-        // 正しい値が learning_plan に残るよう週範囲を再同期する。
-        // (詳細: https://github.com/HIROMICHIplusSHI/pdca-mcp/issues/3)
+      } catch (e) {
+        if (e instanceof ApiError) {
+          return formatError(e.code, e.status, e.details);
+        }
+        return formatError('NETWORK_ERROR', 0);
+      }
+
+      // goal_update 後、バックエンドが pdca_reports_controller 経由で
+      // report.learning_plan を daily_goal_items.first.content で上書きしうるため、
+      // 正しい値が learning_plan に残るよう週範囲を再同期する（ベストエフォート）。
+      // 同期呼び出しの失敗が goal_update 本体の成功レスポンスを false negative 化しないよう
+      // 明示的に分離した try/catch で囲む。
+      // (詳細: https://github.com/HIROMICHIplusSHI/pdca-mcp/issues/3)
+      try {
         const goal = response?.weekly_goal;
+        // response は 204 No Content 応答時に null、goal が undefined になる可能性があるので防御
         if (goal?.week_start_date && goal?.week_end_date) {
           await syncReportLearningPlanForWeek(
             apiClient,
@@ -96,13 +108,11 @@ export function registerGoalTools(server: McpServer, apiClient: ApiClient): void
             goal.week_end_date
           );
         }
-        return formatSuccess(response);
       } catch (e) {
-        if (e instanceof ApiError) {
-          return formatError(e.code, e.status, e.details);
-        }
-        return formatError('NETWORK_ERROR', 0);
+        console.error('[goal_update] sync 呼び出しに失敗:', e);
       }
+
+      return formatSuccess(response);
     }
   );
 }

--- a/src/utils/sync-report-learning-plan.ts
+++ b/src/utils/sync-report-learning-plan.ts
@@ -9,6 +9,15 @@ import type { DailyGoal, Report } from '../types/api-types.js';
  * MCP/CLI 等のAPIクライアントが `report.learning_plan` を信頼する運用のため、
  * goal_update 後に改めて daily_goal_items→learning_plan の再同期を行う。
  *
+ * ⚠️ 方向の対称性:
+ * - 本ヘルパー: `daily_goal_items → report.learning_plan`（goal_update 起点）
+ * - sync-daily-goal.ts: `report.learning_plan → daily_goal_items`（report_create/update 起点）
+ *
+ * どちらも該当ツール成功時のみ発動するため、単発ツール呼び出しでは衝突しない。
+ * 連続呼び出し時は「最後に叩いたツールの入力が勝つ」挙動となる。
+ * なお koki-kato/pdca-app#93（自動テンプレート廃止）が成立すれば
+ * 本ヘルパーは不要化できる見込み。
+ *
  * 仕様:
  * - weekStart/weekEnd どちらか未指定なら no-op
  * - 開始日 > 終了日なら no-op
@@ -34,36 +43,53 @@ export async function syncReportLearningPlanForWeek(
 }
 
 async function syncOneDay(apiClient: ApiClient, date: string): Promise<void> {
+  let dailyGoal: DailyGoal | undefined;
   try {
     const dailyParams = new URLSearchParams({ date });
     const dailyRes = await apiClient.get<{ daily_goals: DailyGoal[] }>(
       `/api/v1/daily_goals?${dailyParams}`
     );
-    const dailyGoal = dailyRes?.daily_goals?.[0];
-    if (!dailyGoal || !dailyGoal.items?.length) return;
+    dailyGoal = dailyRes?.daily_goals?.[0];
+  } catch (e) {
+    console.error(`[sync-report-learning-plan] daily_goals GET失敗 (${date}):`, e);
+    return;
+  }
 
-    const sorted = [...dailyGoal.items].sort((a, b) => a.position - b.position);
-    const contents = sorted.map((i) => i.content ?? '');
-    const allBlank = contents.every((c) => c === '');
-    if (allBlank) return;
+  if (!dailyGoal || !dailyGoal.items?.length) return;
 
-    const joined = contents.join('\n');
+  const sorted = [...dailyGoal.items].sort((a, b) => a.position - b.position);
+  const contents = sorted.map((i) => i.content ?? '');
+  // 全item空の場合はスキップ（既存の learning_plan を空文字で上書きしないための防御）
+  const allBlank = contents.every((c) => c === '');
+  if (allBlank) return;
 
+  const joined = contents.join('\n');
+
+  let report: Report | null | undefined;
+  try {
     const reportParams = new URLSearchParams({ date });
     const reportRes = await apiClient.get<{ report: Report | null }>(
       `/api/v1/reports/by_date?${reportParams}`
     );
-    const report = reportRes?.report;
-    if (!report) return;
+    report = reportRes?.report;
+  } catch (e) {
+    console.error(`[sync-report-learning-plan] report GET失敗 (${date}):`, e);
+    return;
+  }
 
-    if (report.learning_plan === joined) return;
+  if (!report) return;
+  if (report.learning_plan === joined) return;
 
+  try {
     await apiClient.patch<{ report: Report }>(
       `/api/v1/reports/${report.id}`,
       { report: { learning_plan: joined } }
     );
   } catch (e) {
-    console.error(`[sync-report-learning-plan] ${date} の同期に失敗:`, e);
+    console.error(
+      `[sync-report-learning-plan] report PATCH失敗 (report_id=${report.id}, date=${date}):`,
+      e
+    );
   }
 }
 

--- a/src/utils/sync-report-learning-plan.ts
+++ b/src/utils/sync-report-learning-plan.ts
@@ -37,9 +37,14 @@ export async function syncReportLearningPlanForWeek(
   if (dates.length === 0) return;
 
   // 順次処理: テスト容易性とエラー局所化のため並列化しない（週7日程度なら実用上問題なし）
+  const startedAt = Date.now();
   for (const date of dates) {
     await syncOneDay(apiClient, date);
   }
+  const elapsedMs = Date.now() - startedAt;
+  console.error(
+    `[sync-report-learning-plan] ${dates.length}日分の同期完了 (${elapsedMs}ms)`
+  );
 }
 
 async function syncOneDay(apiClient: ApiClient, date: string): Promise<void> {

--- a/src/utils/sync-report-learning-plan.ts
+++ b/src/utils/sync-report-learning-plan.ts
@@ -1,0 +1,82 @@
+import type { ApiClient } from '../client/api-client.js';
+import type { DailyGoal, Report } from '../types/api-types.js';
+
+/**
+ * 指定週の各日について、`daily_goal_items[].content` を `report.learning_plan` に反映する。
+ *
+ * 背景: `goal_update` 実行後、バックエンド側の pdca_reports_controller が
+ * `learning_plan = daily_goal_items.first.content` で上書きするケースがある。
+ * MCP/CLI 等のAPIクライアントが `report.learning_plan` を信頼する運用のため、
+ * goal_update 後に改めて daily_goal_items→learning_plan の再同期を行う。
+ *
+ * 仕様:
+ * - weekStart/weekEnd どちらか未指定なら no-op
+ * - 開始日 > 終了日なら no-op
+ * - 各日について daily_goals の GET、report の by_date GET、必要なら report の PATCH
+ * - daily_goal/items/report の欠落は silent skip
+ * - 個別日の失敗は他日の処理を阻害しない（ベストエフォート）
+ * - 現在の learning_plan と join 後の内容が一致していれば PATCH しない（無駄呼び防止）
+ */
+export async function syncReportLearningPlanForWeek(
+  apiClient: ApiClient,
+  weekStart: string,
+  weekEnd: string
+): Promise<void> {
+  if (!weekStart || !weekEnd) return;
+
+  const dates = enumerateDates(weekStart, weekEnd);
+  if (dates.length === 0) return;
+
+  // 順次処理: テスト容易性とエラー局所化のため並列化しない（週7日程度なら実用上問題なし）
+  for (const date of dates) {
+    await syncOneDay(apiClient, date);
+  }
+}
+
+async function syncOneDay(apiClient: ApiClient, date: string): Promise<void> {
+  try {
+    const dailyParams = new URLSearchParams({ date });
+    const dailyRes = await apiClient.get<{ daily_goals: DailyGoal[] }>(
+      `/api/v1/daily_goals?${dailyParams}`
+    );
+    const dailyGoal = dailyRes?.daily_goals?.[0];
+    if (!dailyGoal || !dailyGoal.items?.length) return;
+
+    const sorted = [...dailyGoal.items].sort((a, b) => a.position - b.position);
+    const contents = sorted.map((i) => i.content ?? '');
+    const allBlank = contents.every((c) => c === '');
+    if (allBlank) return;
+
+    const joined = contents.join('\n');
+
+    const reportParams = new URLSearchParams({ date });
+    const reportRes = await apiClient.get<{ report: Report | null }>(
+      `/api/v1/reports/by_date?${reportParams}`
+    );
+    const report = reportRes?.report;
+    if (!report) return;
+
+    if (report.learning_plan === joined) return;
+
+    await apiClient.patch<{ report: Report }>(
+      `/api/v1/reports/${report.id}`,
+      { report: { learning_plan: joined } }
+    );
+  } catch (e) {
+    console.error(`[sync-report-learning-plan] ${date} の同期に失敗:`, e);
+  }
+}
+
+function enumerateDates(start: string, end: string): string[] {
+  const s = new Date(start + 'T00:00:00Z');
+  const e = new Date(end + 'T00:00:00Z');
+  if (isNaN(s.getTime()) || isNaN(e.getTime())) return [];
+  if (s > e) return [];
+  const out: string[] = [];
+  const cur = new Date(s);
+  while (cur <= e) {
+    out.push(cur.toISOString().slice(0, 10));
+    cur.setUTCDate(cur.getUTCDate() + 1);
+  }
+  return out;
+}

--- a/tests/utils/sync-report-learning-plan.test.ts
+++ b/tests/utils/sync-report-learning-plan.test.ts
@@ -17,10 +17,21 @@ describe('syncReportLearningPlanForWeek', () => {
     } as unknown as ApiClient;
   });
 
-  it('週範囲が未指定ならapiClientを呼ばない', async () => {
+  it('weekStart が空ならapiClientを呼ばない', async () => {
     await syncReportLearningPlanForWeek(apiClient, '', '2026-04-24');
     expect(apiClient.get).not.toHaveBeenCalled();
     expect(apiClient.patch).not.toHaveBeenCalled();
+  });
+
+  it('weekEnd が空ならapiClientを呼ばない', async () => {
+    await syncReportLearningPlanForWeek(apiClient, '2026-04-18', '');
+    expect(apiClient.get).not.toHaveBeenCalled();
+    expect(apiClient.patch).not.toHaveBeenCalled();
+  });
+
+  it('不正な日付文字列なら何もしない', async () => {
+    await syncReportLearningPlanForWeek(apiClient, 'not-a-date', '2026-04-24');
+    expect(apiClient.get).not.toHaveBeenCalled();
   });
 
   it('日次目標のcontentsをreport.learning_planへ反映する', async () => {
@@ -121,6 +132,99 @@ describe('syncReportLearningPlanForWeek', () => {
         }],
       })
       .mockResolvedValueOnce({ report: null });
+
+    await syncReportLearningPlanForWeek(apiClient, '2026-04-18', '2026-04-18');
+
+    expect(apiClient.patch).not.toHaveBeenCalled();
+  });
+
+  it('部分的に空contentが含まれる場合は空行付きで結合される', async () => {
+    (apiClient.get as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({
+        daily_goals: [{
+          id: 100,
+          goal_date: '2026-04-18',
+          weekly_goal_id: 1,
+          items: [
+            { id: 11, content: 'A', progress: 0, position: 0 },
+            { id: 12, content: '', progress: 0, position: 1 },
+            { id: 13, content: 'C', progress: 0, position: 2 },
+          ],
+        }],
+      })
+      .mockResolvedValueOnce({
+        report: { id: 1001, report_date: '2026-04-18', learning_plan: 'old' },
+      });
+
+    await syncReportLearningPlanForWeek(apiClient, '2026-04-18', '2026-04-18');
+
+    expect(apiClient.patch).toHaveBeenCalledWith(
+      '/api/v1/reports/1001',
+      { report: { learning_plan: 'A\n\nC' } }
+    );
+  });
+
+  it('items空配列（daily_goalはあるがitems=[]）なら更新しない', async () => {
+    (apiClient.get as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({
+        daily_goals: [{
+          id: 100,
+          goal_date: '2026-04-18',
+          weekly_goal_id: 1,
+          items: [],
+        }],
+      });
+
+    await syncReportLearningPlanForWeek(apiClient, '2026-04-18', '2026-04-18');
+
+    expect(apiClient.patch).not.toHaveBeenCalled();
+  });
+
+  it('daily_goalsキー欠落レスポンスでも更新しない', async () => {
+    (apiClient.get as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({});
+
+    await syncReportLearningPlanForWeek(apiClient, '2026-04-18', '2026-04-18');
+
+    expect(apiClient.patch).not.toHaveBeenCalled();
+  });
+
+  it('item.content が null/undefined なら空文字として扱う', async () => {
+    (apiClient.get as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({
+        daily_goals: [{
+          id: 100,
+          goal_date: '2026-04-18',
+          weekly_goal_id: 1,
+          items: [
+            { id: 11, content: 'A', progress: 0, position: 0 },
+            { id: 12, content: null, progress: 0, position: 1 },
+          ],
+        }],
+      })
+      .mockResolvedValueOnce({
+        report: { id: 1001, report_date: '2026-04-18', learning_plan: 'old' },
+      });
+
+    await syncReportLearningPlanForWeek(apiClient, '2026-04-18', '2026-04-18');
+
+    expect(apiClient.patch).toHaveBeenCalledWith(
+      '/api/v1/reports/1001',
+      { report: { learning_plan: 'A\n' } }
+    );
+  });
+
+  it('report GET が null(204相当) を返したらスキップ', async () => {
+    (apiClient.get as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({
+        daily_goals: [{
+          id: 100,
+          goal_date: '2026-04-18',
+          weekly_goal_id: 1,
+          items: [{ id: 11, content: 'A', progress: 0, position: 0 }],
+        }],
+      })
+      .mockResolvedValueOnce(null);
 
     await syncReportLearningPlanForWeek(apiClient, '2026-04-18', '2026-04-18');
 

--- a/tests/utils/sync-report-learning-plan.test.ts
+++ b/tests/utils/sync-report-learning-plan.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { syncReportLearningPlanForWeek } from '../../src/utils/sync-report-learning-plan.js';
+import type { ApiClient } from '../../src/client/api-client.js';
+import { ApiError } from '../../src/client/api-client.js';
+
+describe('syncReportLearningPlanForWeek', () => {
+  let apiClient: ApiClient;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    apiClient = {
+      get: vi.fn(),
+      post: vi.fn(),
+      patch: vi.fn(),
+      delete: vi.fn(),
+    } as unknown as ApiClient;
+  });
+
+  it('週範囲が未指定ならapiClientを呼ばない', async () => {
+    await syncReportLearningPlanForWeek(apiClient, '', '2026-04-24');
+    expect(apiClient.get).not.toHaveBeenCalled();
+    expect(apiClient.patch).not.toHaveBeenCalled();
+  });
+
+  it('日次目標のcontentsをreport.learning_planへ反映する', async () => {
+    (apiClient.get as ReturnType<typeof vi.fn>)
+      // /api/v1/daily_goals?date=2026-04-18
+      .mockResolvedValueOnce({
+        daily_goals: [{
+          id: 100,
+          goal_date: '2026-04-18',
+          weekly_goal_id: 1,
+          items: [
+            { id: 11, content: 'MCP実装', progress: 0, position: 0 },
+          ],
+        }],
+      })
+      // /api/v1/reports/by_date?date=2026-04-18
+      .mockResolvedValueOnce({
+        report: {
+          id: 1001,
+          report_date: '2026-04-18',
+          learning_plan: '14%まで進める',
+        },
+      });
+
+    await syncReportLearningPlanForWeek(apiClient, '2026-04-18', '2026-04-18');
+
+    expect(apiClient.patch).toHaveBeenCalledWith(
+      '/api/v1/reports/1001',
+      { report: { learning_plan: 'MCP実装' } }
+    );
+  });
+
+  it('複数itemは改行連結、position昇順', async () => {
+    (apiClient.get as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({
+        daily_goals: [{
+          id: 100,
+          goal_date: '2026-04-18',
+          weekly_goal_id: 1,
+          items: [
+            { id: 12, content: '目標B', progress: 0, position: 1 },
+            { id: 11, content: '目標A', progress: 0, position: 0 },
+          ],
+        }],
+      })
+      .mockResolvedValueOnce({
+        report: { id: 1001, report_date: '2026-04-18', learning_plan: '' },
+      });
+
+    await syncReportLearningPlanForWeek(apiClient, '2026-04-18', '2026-04-18');
+
+    expect(apiClient.patch).toHaveBeenCalledWith(
+      '/api/v1/reports/1001',
+      { report: { learning_plan: '目標A\n目標B' } }
+    );
+  });
+
+  it('report.learning_planが既に期待値と同じなら更新しない', async () => {
+    (apiClient.get as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({
+        daily_goals: [{
+          id: 100,
+          goal_date: '2026-04-18',
+          weekly_goal_id: 1,
+          items: [{ id: 11, content: 'MCP実装', progress: 0, position: 0 }],
+        }],
+      })
+      .mockResolvedValueOnce({
+        report: {
+          id: 1001,
+          report_date: '2026-04-18',
+          learning_plan: 'MCP実装',
+        },
+      });
+
+    await syncReportLearningPlanForWeek(apiClient, '2026-04-18', '2026-04-18');
+
+    expect(apiClient.patch).not.toHaveBeenCalled();
+  });
+
+  it('daily_goalが無い日はスキップ', async () => {
+    (apiClient.get as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({ daily_goals: [] });
+
+    await syncReportLearningPlanForWeek(apiClient, '2026-04-18', '2026-04-18');
+
+    expect(apiClient.patch).not.toHaveBeenCalled();
+  });
+
+  it('reportが無い日はスキップ', async () => {
+    (apiClient.get as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({
+        daily_goals: [{
+          id: 100,
+          goal_date: '2026-04-18',
+          weekly_goal_id: 1,
+          items: [{ id: 11, content: 'MCP実装', progress: 0, position: 0 }],
+        }],
+      })
+      .mockResolvedValueOnce({ report: null });
+
+    await syncReportLearningPlanForWeek(apiClient, '2026-04-18', '2026-04-18');
+
+    expect(apiClient.patch).not.toHaveBeenCalled();
+  });
+
+  it('items全て空contentなら更新しない', async () => {
+    (apiClient.get as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({
+        daily_goals: [{
+          id: 100,
+          goal_date: '2026-04-18',
+          weekly_goal_id: 1,
+          items: [{ id: 11, content: '', progress: 0, position: 0 }],
+        }],
+      });
+
+    await syncReportLearningPlanForWeek(apiClient, '2026-04-18', '2026-04-18');
+
+    expect(apiClient.patch).not.toHaveBeenCalled();
+  });
+
+  it('範囲が複数日ならすべての日を処理', async () => {
+    const get = apiClient.get as ReturnType<typeof vi.fn>;
+    // 4/18: 日次あり→report存在→更新あり
+    get.mockResolvedValueOnce({
+      daily_goals: [{ id: 100, goal_date: '2026-04-18', weekly_goal_id: 1,
+        items: [{ id: 11, content: 'A', progress: 0, position: 0 }] }],
+    });
+    get.mockResolvedValueOnce({
+      report: { id: 1001, report_date: '2026-04-18', learning_plan: 'old' },
+    });
+    // 4/19: 日次なし
+    get.mockResolvedValueOnce({ daily_goals: [] });
+    // 4/20: 日次あり→report無し
+    get.mockResolvedValueOnce({
+      daily_goals: [{ id: 102, goal_date: '2026-04-20', weekly_goal_id: 1,
+        items: [{ id: 13, content: 'B', progress: 0, position: 0 }] }],
+    });
+    get.mockResolvedValueOnce({ report: null });
+
+    await syncReportLearningPlanForWeek(apiClient, '2026-04-18', '2026-04-20');
+
+    expect(apiClient.patch).toHaveBeenCalledTimes(1);
+    expect(apiClient.patch).toHaveBeenCalledWith(
+      '/api/v1/reports/1001',
+      { report: { learning_plan: 'A' } }
+    );
+  });
+
+  it('個別 GET/PATCH 失敗でも他日の処理は継続する', async () => {
+    const get = apiClient.get as ReturnType<typeof vi.fn>;
+    // 4/18: GET成功→PATCH失敗
+    get.mockResolvedValueOnce({
+      daily_goals: [{ id: 100, goal_date: '2026-04-18', weekly_goal_id: 1,
+        items: [{ id: 11, content: 'A', progress: 0, position: 0 }] }],
+    });
+    get.mockResolvedValueOnce({
+      report: { id: 1001, report_date: '2026-04-18', learning_plan: 'old' },
+    });
+    // 4/19: daily_goals GETでエラー
+    get.mockRejectedValueOnce(new ApiError('SERVER_ERROR', 500));
+    // 4/20: 正常更新
+    get.mockResolvedValueOnce({
+      daily_goals: [{ id: 102, goal_date: '2026-04-20', weekly_goal_id: 1,
+        items: [{ id: 13, content: 'C', progress: 0, position: 0 }] }],
+    });
+    get.mockResolvedValueOnce({
+      report: { id: 1003, report_date: '2026-04-20', learning_plan: 'old3' },
+    });
+
+    (apiClient.patch as ReturnType<typeof vi.fn>)
+      .mockRejectedValueOnce(new ApiError('SERVER_ERROR', 500))
+      .mockResolvedValueOnce({});
+
+    await expect(
+      syncReportLearningPlanForWeek(apiClient, '2026-04-18', '2026-04-20')
+    ).resolves.toBeUndefined();
+
+    expect(apiClient.patch).toHaveBeenCalledTimes(2);
+    expect(apiClient.patch).toHaveBeenNthCalledWith(
+      2,
+      '/api/v1/reports/1003',
+      { report: { learning_plan: 'C' } }
+    );
+  });
+
+  it('開始日 > 終了日なら何もしない', async () => {
+    await syncReportLearningPlanForWeek(apiClient, '2026-04-20', '2026-04-18');
+    expect(apiClient.get).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 概要

PR #2 のレビュー中に発見された副次現象への対応 (#3)。`goal_update` 実行後、バックエンド側で `report.learning_plan` が `daily_goal_items.first.content`（自動テンプレ文言含む）で上書きされ、APIクライアントが古いカスタム文言を取り出してしまう問題。

MCP側で `goal_update` 成功後に該当週範囲を再同期することで暫定対応。

## 変更内容

- `src/utils/sync-report-learning-plan.ts`: 新規ヘルパー
  - 週範囲の各日を順次処理
  - `daily_goal_items` を position 昇順で改行連結 → `report.learning_plan` に反映
  - daily_goal / items / report 欠落や個別失敗は silent skip
  - 既に一致していれば PATCH しない（無駄呼び防止）
- `src/tools/goals.ts`: `goal_update` handler を `formatSuccess`/`formatError` 方式に切替、成功後に `syncReportLearningPlanForWeek` を呼び出し
- `tests/utils/sync-report-learning-plan.test.ts`: 10ケース（TDD先行）

## テスト

- ユニット: 73 → 83 tests（+10）、全PASS
- build OK

## 関連

- Closes HIROMICHIplusSHI/pdca-mcp#3
- 関連: [koki-kato/pdca-app#93](https://github.com/koki-kato/pdca-app/issues/93) — バックエンド側で自動テンプレート機能廃止が決まれば、本ヘルパーは不要化できる見込み
- Base branch: `feat/npm-publish` — npm 公開対応 PR #4 に取り込んだ上でパッケージ化を進める想定

## Test Plan

- [ ] CI全緑
- [ ] マージ後、手動で `goal_update` 実行 → 該当週の `report_show` で `learning_plan` が daily_goal_items と一致することを確認
- [ ] `goal_update` API 失敗時は同期処理が走らないことを確認
- [ ] `learning_plan` と `daily_goal_items` が既に一致していれば PATCH されないことを確認